### PR TITLE
Add .json support to Web.config

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <remove fileExtension=".json" />
+      <mimeMap fileExtension=".json" mimeType="application/json" />
+    </staticContent>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Add `.json` support to **Web.config** in an attempt to fix https://content-search-demo-qa.ritterim.com/search.json returning a 404.