### PR TITLE
Set enableXFF to true

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -25,5 +25,6 @@
         </rule>
       </rules>
     </rewrite>
+    <iisnode enableXFF="true" />
   </system.webServer>
 </configuration>


### PR DESCRIPTION
Expose the `X-Forwarded-For` and `X-Forwarded-Proto` headers to Node.js for an Azure web app.

## Reference

https://github.com/tjanczuk/iisnode/blob/c816a6740ae63e2c3065653539ea18b9c5edfce6/src/samples/configuration/web.config#L99 -- the https://github.com/tjanczuk/iisnode/releases/tag/v0.2.11 release adds the `X-Forwarded-Proto` header when `enableXFF` is enabled.